### PR TITLE
Custom serialize deserialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+*.xml
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 .gradle
 build/
+.idea
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-
+gradle/wrapper
 ### IntelliJ IDEA ###
 .idea/modules.xml
 .idea/jarRepositories.xml
@@ -13,6 +14,10 @@ build/
 *.iml
 *.ipr
 *.xml
+*.bat
+*.jar
+
+gradlew
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     compileOnly 'org.projectlombok:lombok:1.18.42'
     annotationProcessor 'org.projectlombok:lombok:1.18.42'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.20.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.20.0'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java'
+}
+
+group = 'nsu.sd'
+version = '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    compileOnly 'org.projectlombok:lombok:1.18.42'
+    annotationProcessor 'org.projectlombok:lombok:1.18.42'
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'java'
+

--- a/src/main/java/nsu/sd/Blob.java
+++ b/src/main/java/nsu/sd/Blob.java
@@ -1,0 +1,4 @@
+package nsu.sd;
+
+public class Blob {
+}

--- a/src/main/java/nsu/sd/Blob.java
+++ b/src/main/java/nsu/sd/Blob.java
@@ -1,4 +1,14 @@
 package nsu.sd;
 
+import nsu.sd.annotations.JsonElement;
+import nsu.sd.annotations.JsonIgnore;
+import nsu.sd.annotations.JsonSerializable;
+
+@JsonSerializable
 public class Blob {
+    @JsonElement(name = "CoolName")
+    String name;
+    @JsonIgnore
+    String surname;
+    int age;
 }

--- a/src/main/java/nsu/sd/JsonMapper.java
+++ b/src/main/java/nsu/sd/JsonMapper.java
@@ -1,0 +1,56 @@
+package nsu.sd;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import nsu.sd.serializers.CustomJsonDeserializer;
+import nsu.sd.serializers.CustomJsonSerializer;
+
+public class JsonMapper {
+    private final ObjectMapper mapper;
+    private final MetadataRegistry registry;
+
+    public JsonMapper() {
+        this.registry = new MetadataRegistry();
+        this.mapper = new ObjectMapper();
+        this.mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+
+        SimpleModule module = new SimpleModule();
+
+        module.setSerializerModifier(new BeanSerializerModifier() {
+            @Override
+            public JsonSerializer<?> modifySerializer(SerializationConfig config,
+                                                      BeanDescription beanDesc, JsonSerializer<?> defaultSerializer) {
+                if (MetadataRegistry.isSerializable(beanDesc.getBeanClass())) {
+                    return new CustomJsonSerializer(registry);
+                }
+                return defaultSerializer;
+            }
+        });
+
+        module.setDeserializerModifier(new BeanDeserializerModifier() {
+            @Override
+            public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config,
+                                                          BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
+                if (MetadataRegistry.isSerializable(beanDesc.getBeanClass())) {
+                    return new CustomJsonDeserializer(registry);
+                }
+                return deserializer;
+            }
+        });
+
+        mapper.registerModule(module);
+    }
+
+    public String toJson(Object obj) throws JsonProcessingException {
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+    }
+
+    public Object fromJson(String json, Class<?> clazz) throws JsonProcessingException {
+        return mapper.readValue(json, clazz);
+    }
+}

--- a/src/main/java/nsu/sd/JsonMapper.java
+++ b/src/main/java/nsu/sd/JsonMapper.java
@@ -10,6 +10,13 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import nsu.sd.serializers.CustomJsonDeserializer;
 import nsu.sd.serializers.CustomJsonSerializer;
 
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Главный класс, который настраивает перехват работы джексона кастомными (де)сериализаторами.
+ * Для вызовов сериализации и десериализации нужно использовать его.
+ */
 public class JsonMapper {
     private final ObjectMapper mapper;
     private final MetadataRegistry registry;
@@ -46,11 +53,21 @@ public class JsonMapper {
         mapper.registerModule(module);
     }
 
+    // Для строк
     public String toJson(Object obj) throws JsonProcessingException {
         return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
     }
 
     public Object fromJson(String json, Class<?> clazz) throws JsonProcessingException {
         return mapper.readValue(json, clazz);
+    }
+
+    // Для файлов
+    public void toJsonFile(File file, Object obj) throws IOException {
+        mapper.writerWithDefaultPrettyPrinter().writeValue(file, obj);
+    }
+
+    public Object fromJsonFile(File file, Class<?> clazz) throws IOException {
+        return mapper.readValue(file, clazz);
     }
 }

--- a/src/main/java/nsu/sd/Main.java
+++ b/src/main/java/nsu/sd/Main.java
@@ -1,17 +1,50 @@
 package nsu.sd;
 
 import nsu.sd.metadata.ClassMetadata;
+import nsu.sd.testClasses.Address;
+import nsu.sd.testClasses.Blob;
+import nsu.sd.testClasses.Student;
 
 public class Main {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         Blob blob = new Blob();
-        blob.name = "Blob";
-        blob.surname = "Blobov";
-        blob.age = 5;
+        blob.setName("Blob");
+        blob.setSurname("Blobov");
+        blob.setAge(5);
 
         MetadataRegistry registry = new MetadataRegistry();
         ClassMetadata md = registry.getClassMetadata(blob);
-        System.out.println(md.getName());
+        System.out.println(md.getName() + "\n");
 
+        JsonMapper mapper = new JsonMapper();
+
+        String json = mapper.toJson(blob);
+        System.out.println(json);
+
+        Blob restoredBlob = (Blob) mapper.fromJson(json, Blob.class);
+        System.out.println("\nRestored object: ");
+        System.out.println("Name: " + restoredBlob.getName());
+        System.out.println("Age: " + restoredBlob.getAge());
+        System.out.println("Surname: " + restoredBlob.getSurname()); // Должно быть null
+
+        // Вложенный объект
+        Address address = new Address();
+        address.setCity("Novosibirsk");
+        address.setStreet("Pirogova");
+        address.setHouseNumber(1);
+
+        Student anton = new Student();
+        anton.setName("Anton");
+        anton.setAge(13);
+        anton.setHomeAddress(address);
+
+        String antonJson = mapper.toJson(anton);
+        System.out.println("\n" + antonJson);
+
+        Student restoredAnton = (Student) mapper.fromJson(antonJson, Student.class);
+        System.out.println("\nRestored student: ");
+        System.out.println("Name: " + restoredAnton.getName());
+        System.out.println("Age: " + restoredAnton.getAge());
+        System.out.println("Address: " + restoredAnton.getHomeAddress());
     }
 }

--- a/src/main/java/nsu/sd/Main.java
+++ b/src/main/java/nsu/sd/Main.java
@@ -1,17 +1,17 @@
 package nsu.sd;
 
-//TIP To <b>Run</b> code, press <shortcut actionId="Run"/> or
-// click the <icon src="AllIcons.Actions.Execute"/> icon in the gutter.
+import nsu.sd.metadata.ClassMetadata;
+
 public class Main {
     public static void main(String[] args) {
-        //TIP Press <shortcut actionId="ShowIntentionActions"/> with your caret at the highlighted text
-        // to see how IntelliJ IDEA suggests fixing it.
-        System.out.printf("Hello and welcome!");
+        Blob blob = new Blob();
+        blob.name = "Blob";
+        blob.surname = "Blobov";
+        blob.age = 5;
 
-        for (int i = 1; i <= 5; i++) {
-            //TIP Press <shortcut actionId="Debug"/> to start debugging your code. We have set one <icon src="AllIcons.Debugger.Db_set_breakpoint"/> breakpoint
-            // for you, but you can always add more by pressing <shortcut actionId="ToggleLineBreakpoint"/>.
-            System.out.println("i = " + i);
-        }
+        MetadataRegistry registry = new MetadataRegistry();
+        ClassMetadata md = registry.getClassMetadata(blob);
+        System.out.println(md.getName());
+
     }
 }

--- a/src/main/java/nsu/sd/Main.java
+++ b/src/main/java/nsu/sd/Main.java
@@ -1,0 +1,17 @@
+package nsu.sd;
+
+//TIP To <b>Run</b> code, press <shortcut actionId="Run"/> or
+// click the <icon src="AllIcons.Actions.Execute"/> icon in the gutter.
+public class Main {
+    public static void main(String[] args) {
+        //TIP Press <shortcut actionId="ShowIntentionActions"/> with your caret at the highlighted text
+        // to see how IntelliJ IDEA suggests fixing it.
+        System.out.printf("Hello and welcome!");
+
+        for (int i = 1; i <= 5; i++) {
+            //TIP Press <shortcut actionId="Debug"/> to start debugging your code. We have set one <icon src="AllIcons.Debugger.Db_set_breakpoint"/> breakpoint
+            // for you, but you can always add more by pressing <shortcut actionId="ToggleLineBreakpoint"/>.
+            System.out.println("i = " + i);
+        }
+    }
+}

--- a/src/main/java/nsu/sd/Main.java
+++ b/src/main/java/nsu/sd/Main.java
@@ -5,6 +5,8 @@ import nsu.sd.testClasses.Address;
 import nsu.sd.testClasses.Blob;
 import nsu.sd.testClasses.Student;
 
+import java.io.File;
+
 public class Main {
     public static void main(String[] args) throws Exception {
         Blob blob = new Blob();
@@ -46,5 +48,16 @@ public class Main {
         System.out.println("Name: " + restoredAnton.getName());
         System.out.println("Age: " + restoredAnton.getAge());
         System.out.println("Address: " + restoredAnton.getHomeAddress());
+
+        // Запись в файл
+        File myFile = new File("blob.json");
+        mapper.toJsonFile(myFile, blob);
+        System.out.println("\nBlob has been serialized in file.");
+
+        Blob restoredBlob2 = (Blob) mapper.fromJsonFile(myFile, Blob.class);
+        System.out.println("\nRestored object from file: ");
+        System.out.println("Name: " + restoredBlob2.getName());
+        System.out.println("Age: " + restoredBlob2.getAge());
+        System.out.println("Surname: " + restoredBlob2.getSurname());
     }
 }

--- a/src/main/java/nsu/sd/MetadataRegistry.java
+++ b/src/main/java/nsu/sd/MetadataRegistry.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 /**
  * Точка входа к метаданным.
  * Serializer должен проверить, что object isSerializable, а далее если да, взять его из registry
+ * Лениво подгружает аннотации, при первом обращении
  */
 public class MetadataRegistry {
     private final Map<Class<?>, ClassMetadata> registry;

--- a/src/main/java/nsu/sd/MetadataRegistry.java
+++ b/src/main/java/nsu/sd/MetadataRegistry.java
@@ -26,6 +26,10 @@ public class MetadataRegistry {
         return clazz.isAnnotationPresent(JsonSerializable.class);
     }
 
+    public static boolean isSerializable(Class<?> clazz) {
+        return clazz.isAnnotationPresent(JsonSerializable.class);
+    }
+
     public ClassMetadata getClassMetadata(Object object) {
         if (Objects.isNull(object)) {
             throw new IllegalArgumentException("Object is null");

--- a/src/main/java/nsu/sd/MetadataRegistry.java
+++ b/src/main/java/nsu/sd/MetadataRegistry.java
@@ -1,5 +1,6 @@
 package nsu.sd;
 
+import nsu.sd.annotations.JsonSerializable;
 import nsu.sd.metadata.ClassMetadata;
 
 import java.util.HashMap;
@@ -19,14 +20,23 @@ public class MetadataRegistry {
         scanner = new MetadataScanner();
     }
 
+    public static boolean isSerializable(Object object) {
+        Class<?> clazz = object.getClass();
+        return clazz.isAnnotationPresent(JsonSerializable.class);
+    }
+
     public ClassMetadata getClassMetadata(Object object) {
         if (Objects.isNull(object)) {
-            throw new IllegalArgumentException("object is null");
+            throw new IllegalArgumentException("Object is null");
+        }
+
+        if (!isSerializable(object)) {
+            throw new IllegalArgumentException("Object is not serializable");
         }
 
         Class<?> clazz = object.getClass();
         if (!registry.containsKey(clazz)) {
-            ClassMetadata metadata = scanner.getClassMetadata(object);
+            ClassMetadata metadata = scanner.scanCLass(clazz);
             registry.put(clazz, metadata);
             return metadata;
         }

--- a/src/main/java/nsu/sd/MetadataRegistry.java
+++ b/src/main/java/nsu/sd/MetadataRegistry.java
@@ -1,0 +1,9 @@
+package nsu.sd;
+
+import nsu.sd.metadata.ClassMetadata;
+
+import java.util.Map;
+
+public class MetadataRegistry {
+    Map<Class<?>, ClassMetadata> registry;
+}

--- a/src/main/java/nsu/sd/MetadataRegistry.java
+++ b/src/main/java/nsu/sd/MetadataRegistry.java
@@ -2,8 +2,34 @@ package nsu.sd;
 
 import nsu.sd.metadata.ClassMetadata;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
+/**
+ * Точка входа к метаданным.
+ * Serializer должен проверить, что object isSerializable, а далее если да, взять его из registry
+ */
 public class MetadataRegistry {
-    Map<Class<?>, ClassMetadata> registry;
+    private final Map<Class<?>, ClassMetadata> registry;
+    MetadataScanner scanner;
+
+    public MetadataRegistry() {
+        registry = new HashMap<>();
+        scanner = new MetadataScanner();
+    }
+
+    public ClassMetadata getClassMetadata(Object object) {
+        if (Objects.isNull(object)) {
+            throw new IllegalArgumentException("object is null");
+        }
+
+        Class<?> clazz = object.getClass();
+        if (!registry.containsKey(clazz)) {
+            ClassMetadata metadata = scanner.getClassMetadata(object);
+            registry.put(clazz, metadata);
+            return metadata;
+        }
+        return registry.get(clazz);
+    }
 }

--- a/src/main/java/nsu/sd/MetadataScanner.java
+++ b/src/main/java/nsu/sd/MetadataScanner.java
@@ -6,6 +6,7 @@ import nsu.sd.metadata.FieldMetadata;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.Objects;
 
 /**
  * сканирует аннотации из класса
@@ -31,7 +32,7 @@ public class MetadataScanner {
         metadata.setName(field.getName());
         if (field.isAnnotationPresent(JsonElement.class)) {
             JsonElement element = field.getAnnotation(JsonElement.class);
-            if (element.name() != null) {
+            if (!Objects.equals(element.name(), "")) {
                 metadata.setName(element.name());
             }
         }

--- a/src/main/java/nsu/sd/MetadataScanner.java
+++ b/src/main/java/nsu/sd/MetadataScanner.java
@@ -9,40 +9,32 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Serializer сначала проверяет для объекта isSerializable. Если да, то он вызывает getClassMetadata, чтобы получить их
+ */
 public class MetadataScanner {
-    private Map<Class<?>, ClassMetadata> registry;
 
-    public boolean isSerializable(Object object) {
+    public static boolean isSerializable(Object object) {
         Class<?> clazz = object.getClass();
         return clazz.isAnnotationPresent(JsonSerializable.class);
     }
 
     public ClassMetadata getClassMetadata(Object object) {
-        Class<?> clazz = object.getClass();
-        if (!registry.containsKey(clazz)) {
-            ClassMetadata metadata = scanCLass(object, clazz);
-            registry.put(clazz, metadata);
-            return metadata;
-        }
-        return registry.get(clazz);
-    }
-
-    // TODO: create our own exceptions
-    private ClassMetadata scanCLass(Object object, Class<?> clazz) {
-        if (Objects.isNull(object)) {
-            throw new NullPointerException("object is null");
-        }
-
         if (!isSerializable(object)) {
             throw new IllegalArgumentException("object is not serializable");
         }
+        return scanCLass(object.getClass());
+    }
 
+    // TODO: create our own exceptions
+    private ClassMetadata scanCLass(Class<?> clazz) {
         ClassMetadata metadata = new ClassMetadata();
         metadata.setName(clazz.getSimpleName());
         metadata.setClazz(clazz);
         metadata.setSerializable(true);
         metadata.setFields(new HashMap<>());
         for (Field field : clazz.getDeclaredFields()) {
+            field.setAccessible(true);
             FieldMetadata fieldMetadata = getFieldMetadata(field);
             metadata.getFields().put(field.getName(), fieldMetadata);
         }

--- a/src/main/java/nsu/sd/MetadataScanner.java
+++ b/src/main/java/nsu/sd/MetadataScanner.java
@@ -1,0 +1,74 @@
+package nsu.sd;
+
+import nsu.sd.annotations.*;
+import nsu.sd.metadata.ClassMetadata;
+import nsu.sd.metadata.FieldMetadata;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class MetadataScanner {
+    private Map<Class<?>, ClassMetadata> registry;
+
+    public boolean isSerializable(Object object) {
+        Class<?> clazz = object.getClass();
+        return clazz.isAnnotationPresent(JsonSerializable.class);
+    }
+
+    public ClassMetadata getClassMetadata(Object object) {
+        Class<?> clazz = object.getClass();
+        if (!registry.containsKey(clazz)) {
+            ClassMetadata metadata = scanCLass(object, clazz);
+            registry.put(clazz, metadata);
+            return metadata;
+        }
+        return registry.get(clazz);
+    }
+
+    // TODO: create our own exceptions
+    private ClassMetadata scanCLass(Object object, Class<?> clazz) {
+        if (Objects.isNull(object)) {
+            throw new NullPointerException("object is null");
+        }
+
+        if (!isSerializable(object)) {
+            throw new IllegalArgumentException("object is not serializable");
+        }
+
+        ClassMetadata metadata = new ClassMetadata();
+        metadata.setName(clazz.getSimpleName());
+        metadata.setClazz(clazz);
+        metadata.setSerializable(true);
+        metadata.setFields(new HashMap<>());
+        for (Field field : clazz.getDeclaredFields()) {
+            FieldMetadata fieldMetadata = getFieldMetadata(field);
+            metadata.getFields().put(field.getName(), fieldMetadata);
+        }
+        return metadata;
+    }
+
+    private FieldMetadata getFieldMetadata(Field field) {
+        FieldMetadata metadata = new FieldMetadata();
+        metadata.setName(field.getName());
+        if (field.isAnnotationPresent(JsonElement.class)) {
+            JsonElement element = field.getAnnotation(JsonElement.class);
+            if (element.name() != null) {
+                metadata.setName(element.name());
+            }
+        }
+        metadata.setField(field);
+        metadata.setType(field.getGenericType());
+        if (field.isAnnotationPresent(JsonLazy.class)){
+            metadata.setLazy(true);
+        }
+        if (field.isAnnotationPresent(JsonIgnore.class)) {
+            metadata.setIgnore(true);
+        }
+        if (field.isAnnotationPresent(JsonUnwrapped.class)) {
+            metadata.setUnwrapped(true);
+        }
+        return metadata;
+    }
+}

--- a/src/main/java/nsu/sd/MetadataScanner.java
+++ b/src/main/java/nsu/sd/MetadataScanner.java
@@ -6,11 +6,9 @@ import nsu.sd.metadata.FieldMetadata;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 
 /**
- * Serializer сначала проверяет для объекта isSerializable. Если да, то он вызывает getClassMetadata, чтобы получить их
+ * сканирует аннотации из класса
  */
 public class MetadataScanner {
     // TODO: create our own exceptions

--- a/src/main/java/nsu/sd/MetadataScanner.java
+++ b/src/main/java/nsu/sd/MetadataScanner.java
@@ -13,21 +13,8 @@ import java.util.Objects;
  * Serializer сначала проверяет для объекта isSerializable. Если да, то он вызывает getClassMetadata, чтобы получить их
  */
 public class MetadataScanner {
-
-    public static boolean isSerializable(Object object) {
-        Class<?> clazz = object.getClass();
-        return clazz.isAnnotationPresent(JsonSerializable.class);
-    }
-
-    public ClassMetadata getClassMetadata(Object object) {
-        if (!isSerializable(object)) {
-            throw new IllegalArgumentException("object is not serializable");
-        }
-        return scanCLass(object.getClass());
-    }
-
     // TODO: create our own exceptions
-    private ClassMetadata scanCLass(Class<?> clazz) {
+    public ClassMetadata scanCLass(Class<?> clazz) {
         ClassMetadata metadata = new ClassMetadata();
         metadata.setName(clazz.getSimpleName());
         metadata.setClazz(clazz);

--- a/src/main/java/nsu/sd/annotations/JsonAlias.java
+++ b/src/main/java/nsu/sd/annotations/JsonAlias.java
@@ -1,0 +1,12 @@
+package nsu.sd.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface JsonAlias {
+    public String[] keys() default "";
+}

--- a/src/main/java/nsu/sd/annotations/JsonElement.java
+++ b/src/main/java/nsu/sd/annotations/JsonElement.java
@@ -1,0 +1,12 @@
+package nsu.sd.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface JsonElement {
+    public String name() default "";
+}

--- a/src/main/java/nsu/sd/annotations/JsonFormat.java
+++ b/src/main/java/nsu/sd/annotations/JsonFormat.java
@@ -1,0 +1,12 @@
+package nsu.sd.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface JsonFormat {
+    public String format() default "";
+}

--- a/src/main/java/nsu/sd/annotations/JsonIgnore.java
+++ b/src/main/java/nsu/sd/annotations/JsonIgnore.java
@@ -1,0 +1,11 @@
+package nsu.sd.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface JsonIgnore {
+}

--- a/src/main/java/nsu/sd/annotations/JsonLazy.java
+++ b/src/main/java/nsu/sd/annotations/JsonLazy.java
@@ -1,0 +1,11 @@
+package nsu.sd.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface JsonLazy {
+}

--- a/src/main/java/nsu/sd/annotations/JsonSerializable.java
+++ b/src/main/java/nsu/sd/annotations/JsonSerializable.java
@@ -1,0 +1,11 @@
+package nsu.sd.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface JsonSerializable {
+}

--- a/src/main/java/nsu/sd/annotations/JsonUnwrapped.java
+++ b/src/main/java/nsu/sd/annotations/JsonUnwrapped.java
@@ -1,0 +1,12 @@
+package nsu.sd.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface JsonUnwrapped {
+    public String value() default "";
+}

--- a/src/main/java/nsu/sd/metadata/ClassMetadata.java
+++ b/src/main/java/nsu/sd/metadata/ClassMetadata.java
@@ -1,0 +1,19 @@
+package nsu.sd.metadata;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+/**
+ * метаданные класса хранят сам кдасс объекта, полученный через reflection, имя класса
+ * флаг сериалзиации, и все поля объекта
+ */
+@Getter
+@Setter
+public class ClassMetadata {
+    Class<?> clazz;
+    String name;
+    boolean serializable;
+    Map<String, FieldMetadata> fields;
+}

--- a/src/main/java/nsu/sd/metadata/FieldMetadata.java
+++ b/src/main/java/nsu/sd/metadata/FieldMetadata.java
@@ -1,0 +1,22 @@
+package nsu.sd.metadata;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+
+/**
+ * метаданные поля хранят его имя, объект Field, полученный через reflection
+ * тип поля, и флаги сериализации: lazy, ignore(не сериализовать), unwrapped(поле-это вложенный объект)
+ */
+@Getter
+@Setter
+public class FieldMetadata {
+    String name;
+    Field field;
+    Type type;
+    boolean lazy;
+    boolean ignore;
+    boolean unwrapped;
+}

--- a/src/main/java/nsu/sd/serializers/CustomJsonDeserializer.java
+++ b/src/main/java/nsu/sd/serializers/CustomJsonDeserializer.java
@@ -1,0 +1,59 @@
+package nsu.sd.serializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import nsu.sd.metadata.ClassMetadata;
+import nsu.sd.metadata.FieldMetadata;
+import nsu.sd.MetadataRegistry;
+
+import java.io.IOException;
+
+public class CustomJsonDeserializer extends StdDeserializer<Object> {
+
+    private final MetadataRegistry registry;
+    private final ObjectMapper basicMapper;
+
+    public CustomJsonDeserializer(MetadataRegistry registry) {
+        super(Object.class);
+        this.registry = registry;
+        this.basicMapper = new ObjectMapper();
+    }
+
+    @Override
+    public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode node = p.getCodec().readTree(p);
+
+        JsonNode classNameNode = node.get("_className");
+        if (classNameNode == null) {
+            throw new RuntimeException("Unable to deserialize: _className is missing in JSON");
+        }
+
+        String className = classNameNode.asText();
+        try {
+            Class<?> clazz = Class.forName(className);
+            Object instance = clazz.getDeclaredConstructor().newInstance();
+
+            ClassMetadata metadata = registry.getClassMetadata(instance);
+            for (FieldMetadata fieldMeta : metadata.getFields().values()) {
+                if (fieldMeta.isIgnore()) continue;
+
+                String jsonFieldName = fieldMeta.getName();
+                JsonNode fieldNode = node.get(jsonFieldName);
+
+                if (fieldNode != null && !fieldNode.isNull()) {
+                    Class<?> targetClass = fieldMeta.getField().getType();
+                    Object value = p.getCodec().treeToValue(fieldNode, targetClass);
+
+                    fieldMeta.getField().set(instance, value);
+                }
+            }
+            return instance;
+        } catch (Exception e) {
+            System.out.println("Error while deserializing class " + className + " " + e);
+        }
+        return null;
+    }
+}

--- a/src/main/java/nsu/sd/serializers/CustomJsonDeserializer.java
+++ b/src/main/java/nsu/sd/serializers/CustomJsonDeserializer.java
@@ -8,9 +8,14 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import nsu.sd.metadata.ClassMetadata;
 import nsu.sd.metadata.FieldMetadata;
 import nsu.sd.MetadataRegistry;
-
 import java.io.IOException;
 
+/**
+ * Кастомный десериализатор.
+ * Работает только для классов, помеченных @JsonSerializable.
+ * Создает пустой объект,
+ * получает метаданные класса, проходит по ним в цикле и десериализует.
+ */
 public class CustomJsonDeserializer extends StdDeserializer<Object> {
 
     private final MetadataRegistry registry;

--- a/src/main/java/nsu/sd/serializers/CustomJsonSerializer.java
+++ b/src/main/java/nsu/sd/serializers/CustomJsonSerializer.java
@@ -1,0 +1,45 @@
+package nsu.sd.serializers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import nsu.sd.MetadataRegistry;
+import nsu.sd.metadata.ClassMetadata;
+import nsu.sd.metadata.FieldMetadata;
+
+import java.io.IOException;
+
+public class CustomJsonSerializer extends StdSerializer<Object> {
+
+    private final MetadataRegistry registry;
+
+    public CustomJsonSerializer(MetadataRegistry registry) {
+        super(Object.class);
+        this.registry = registry;
+    }
+
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        ClassMetadata metadata = registry.getClassMetadata(value);
+
+        gen.writeStartObject();
+        gen.writeStringField("_className", metadata.getClazz().getName());
+
+        for (FieldMetadata fieldMeta : metadata.getFields().values()) {
+
+            if (fieldMeta.isIgnore()) {
+                continue;
+            }
+
+            try {
+                Object fieldValue = fieldMeta.getField().get(value);
+                gen.writeObjectField(fieldMeta.getName(), fieldValue);
+
+            } catch (IllegalAccessException e) {
+                System.out.println("Error while accessing field: " + fieldMeta.getName() + " " + e);
+            }
+        }
+
+        gen.writeEndObject();
+    }
+}

--- a/src/main/java/nsu/sd/serializers/CustomJsonSerializer.java
+++ b/src/main/java/nsu/sd/serializers/CustomJsonSerializer.java
@@ -9,6 +9,12 @@ import nsu.sd.metadata.FieldMetadata;
 
 import java.io.IOException;
 
+/**
+ * Кастомный сериализатор.
+ * Работает только для классов, помеченных @JsonSerializable.
+ * Получает метаданные класса, проходит по ним в цикле и сериализует.
+ * Не поддерживает циклические ссылки.
+ */
 public class CustomJsonSerializer extends StdSerializer<Object> {
 
     private final MetadataRegistry registry;

--- a/src/main/java/nsu/sd/testClasses/Address.java
+++ b/src/main/java/nsu/sd/testClasses/Address.java
@@ -1,0 +1,14 @@
+package nsu.sd.testClasses;
+
+import lombok.Getter;
+import lombok.Setter;
+import nsu.sd.annotations.JsonSerializable;
+
+@Getter
+@Setter
+@JsonSerializable
+public class Address {
+    String city;
+    String street;
+    int houseNumber;
+}

--- a/src/main/java/nsu/sd/testClasses/Blob.java
+++ b/src/main/java/nsu/sd/testClasses/Blob.java
@@ -1,9 +1,13 @@
-package nsu.sd;
+package nsu.sd.testClasses;
 
+import lombok.Getter;
+import lombok.Setter;
 import nsu.sd.annotations.JsonElement;
 import nsu.sd.annotations.JsonIgnore;
 import nsu.sd.annotations.JsonSerializable;
 
+@Getter
+@Setter
 @JsonSerializable
 public class Blob {
     @JsonElement(name = "CoolName")

--- a/src/main/java/nsu/sd/testClasses/Student.java
+++ b/src/main/java/nsu/sd/testClasses/Student.java
@@ -1,0 +1,14 @@
+package nsu.sd.testClasses;
+
+import lombok.Getter;
+import lombok.Setter;
+import nsu.sd.annotations.JsonSerializable;
+
+@Getter
+@Setter
+@JsonSerializable
+public class Student {
+    String name;
+    int age;
+    Address homeAddress;
+}


### PR DESCRIPTION
- Теперь есть CustomJsonSerializer и CustomJsonDeserializer. Они перехватывают работу джексона, смотрят в алинины метаданные и пишут/читают только то, что нам нужно.
- Точка входа это JsonMapper. Это будет класс, который скрывает внутри себя настройки джексона. Для вызовов сериализации и десериализации нужно использовать его. Пример в мэйне написан. 
    - Также он видит все поля класса, а не только публичные.
- Кастомные сериализаторы включаются только для классов, помеченных @JsonSerializable.
- В FrameworkMapper есть методы, которые (де)сериализуют в строки, и есть которые в файлы.
- Вложенные объекты он сам может обрабатывать, а циклические ссылки нет.
- Для фильтров и ленивой загрузки надо будет работать в CustomJsonDeserializer.