### PR TITLE
Add cyclic and shared links support

### DIFF
--- a/src/main/java/nsu/sd/JsonMapper.java
+++ b/src/main/java/nsu/sd/JsonMapper.java
@@ -54,20 +54,40 @@ public class JsonMapper {
     }
 
     // Для строк
-    public String toJson(Object obj) throws JsonProcessingException {
-        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+    public String toJson(Object obj) throws JsonProcessingException   {
+        CustomJsonSerializer.SEEN_OBJECTS.get().clear();
+        try {
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+        } finally {
+            CustomJsonSerializer.SEEN_OBJECTS.get().clear();
+        }
     }
 
-    public Object fromJson(String json, Class<?> clazz) throws JsonProcessingException {
-        return mapper.readValue(json, clazz);
+    public Object fromJson(String json, Class<?> clazz) throws JsonMappingException, JsonProcessingException   {
+        CustomJsonDeserializer.RESOLVED_OBJECTS.get().clear();
+        try {
+            return mapper.readValue(json, clazz);
+        } finally {
+            CustomJsonDeserializer.RESOLVED_OBJECTS.get().clear();
+        }
     }
 
     // Для файлов
     public void toJsonFile(File file, Object obj) throws IOException {
-        mapper.writerWithDefaultPrettyPrinter().writeValue(file, obj);
+        CustomJsonSerializer.SEEN_OBJECTS.get().clear();
+        try {
+            mapper.writerWithDefaultPrettyPrinter().writeValue(file, obj);
+        } finally {
+            CustomJsonSerializer.SEEN_OBJECTS.get().clear();
+        }
     }
 
     public Object fromJsonFile(File file, Class<?> clazz) throws IOException {
-        return mapper.readValue(file, clazz);
+        CustomJsonDeserializer.RESOLVED_OBJECTS.get().clear();
+        try {
+            return mapper.readValue(file, clazz);
+        } finally {
+            CustomJsonDeserializer.RESOLVED_OBJECTS.get().clear();
+        }
     }
 }

--- a/src/main/java/nsu/sd/serializers/CustomJsonDeserializer.java
+++ b/src/main/java/nsu/sd/serializers/CustomJsonDeserializer.java
@@ -12,6 +12,8 @@ import nsu.sd.metadata.FieldMetadata;
 import nsu.sd.MetadataRegistry;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Кастомный десериализатор.
@@ -22,6 +24,7 @@ import java.lang.reflect.Type;
 public class CustomJsonDeserializer extends StdDeserializer<Object> {
 
     private final MetadataRegistry registry;
+    public static final ThreadLocal<Map<Integer, Object>> RESOLVED_OBJECTS = ThreadLocal.withInitial(HashMap::new);
 
     public CustomJsonDeserializer(MetadataRegistry registry) {
         super(Object.class);
@@ -30,7 +33,18 @@ public class CustomJsonDeserializer extends StdDeserializer<Object> {
 
     @Override
     public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        Map<Integer, Object> resolvedObjects = RESOLVED_OBJECTS.get();
+
         JsonNode node = p.getCodec().readTree(p);
+
+        if (node.has("@ref")) {
+            int refId = node.get("@ref").asInt();
+            Object existingObj = resolvedObjects.get(refId);
+            if (existingObj == null) {
+                throw new RuntimeException("Wrong reference! Object with ID " + refId + " not found.");
+            }
+            return existingObj;
+        }
 
         JsonNode classNameNode = node.get("_className");
         if (classNameNode == null) {
@@ -38,9 +52,14 @@ public class CustomJsonDeserializer extends StdDeserializer<Object> {
         }
 
         String className = classNameNode.asText();
+        int objId = node.has("@id") ? node.get("@id").asInt() : -1;
         try {
             Class<?> clazz = Class.forName(className);
             Object instance = clazz.getDeclaredConstructor().newInstance();
+
+            if (objId != -1) {
+                resolvedObjects.put(objId, instance);
+            }
 
             ClassMetadata metadata = registry.getClassMetadata(instance);
             for (FieldMetadata fieldMeta : metadata.getFields().values()) {

--- a/src/main/java/nsu/sd/serializers/CustomJsonSerializer.java
+++ b/src/main/java/nsu/sd/serializers/CustomJsonSerializer.java
@@ -9,16 +9,18 @@ import nsu.sd.metadata.ClassMetadata;
 import nsu.sd.metadata.FieldMetadata;
 
 import java.io.IOException;
+import java.util.IdentityHashMap;
 
 /**
  * Кастомный сериализатор.
  * Работает только для классов, помеченных @JsonSerializable.
  * Получает метаданные класса, проходит по ним в цикле и сериализует.
- * Не поддерживает циклические ссылки.
+ * Поддерживает циклические ссылки.
  */
 public class CustomJsonSerializer extends StdSerializer<Object> {
 
     private final MetadataRegistry registry;
+    public static final ThreadLocal<IdentityHashMap<Object, Integer>> SEEN_OBJECTS = ThreadLocal.withInitial(IdentityHashMap::new);
 
     public CustomJsonSerializer(MetadataRegistry registry) {
         super(Object.class);
@@ -27,9 +29,22 @@ public class CustomJsonSerializer extends StdSerializer<Object> {
 
     @Override
     public void serialize(Object value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        IdentityHashMap<Object, Integer> seenObjects = SEEN_OBJECTS.get();
+
+        if (seenObjects.containsKey(value)) {
+            gen.writeStartObject();
+            gen.writeNumberField("@ref", seenObjects.get(value));
+            gen.writeEndObject();
+            return;
+        }
+
+        int newId = seenObjects.size() + 1;
+        seenObjects.put(value, newId);
+
         ClassMetadata metadata = registry.getClassMetadata(value);
 
         gen.writeStartObject();
+        gen.writeNumberField("@id", newId);
         gen.writeStringField("_className", metadata.getClazz().getName());
 
         for (FieldMetadata fieldMeta : metadata.getFields().values()) {


### PR DESCRIPTION
Теперь обрабатываются циклические ссылки (студент ссылается на университет, а университет на студента) и разделяемые ссылки (ромбовидный граф: два разработчика ссылаются на один и тот же ноутбук например).
- Используем IdentityHashMap (сравнение по адресам в памяти), чтобы отслеживать уже посещенные участки памяти. 
- При сериализации новому объекту выдается уникальный @id. Если объект встречается повторно в SEEN_OBJECTS, прерываем обход и записываем только короткую ссылку {"@ref": id}.
- При десериализации храним словарь прочитанных объектов RESOLVED_OBJECTS. Встречая {"@ref": 1}, достаем из словаря уже готовый объект.